### PR TITLE
Small recordings for tile API article

### DIFF
--- a/chapter-6/tile-api.md
+++ b/chapter-6/tile-api.md
@@ -7,8 +7,8 @@ The Tile API is a collection of functions that let you modify a scene's terrain 
 
 * Change tile at a location
 * Remove tile at a location
-* Does a tile exist at a given location?
-* What tile exists at a given location? What collision group does it belong to? What tileset does it belong to?
+* Determine whether a tile exists at a given location.
+* Determine what tile exists at a given location. Determine which collision group it belongs to. Determine which tileset it belongs to?
  
 
 ## How do you install the Tile API?


### PR DESCRIPTION
I'm unsure whether the second part of the last bullet point edited is true since all tiles belong to the 'tiles' collision group. Perhaps it should be 'determine which layer the tile is on' instead.