### PR TITLE
Added to Troubleshooting, Keep tile size... Added note.

### DIFF
--- a/chapter-4/tilesets.md
+++ b/chapter-4/tilesets.md
@@ -174,7 +174,7 @@ Tilesets follow this same rule.
 
 ## Troubleshooting
 
-* **Keep the tile size for all tilesets and scenes the same**. For example, if your tilesets have a tile size of 32 x 32, make sure that the scenes also have a tile size of 32 x 32.
+* **Keep the tile size for all tilesets and scenes the same**. For example, if your tilesets have a tile size of 32 x 32, make sure that the scenes also have a tile size of 32 x 32. If they are not the same size, the tiles will be [invisible when testing or publishing the game](http://community.stencyl.com/index.php?issue=122.0).
 
 * When defining custom polygon shapes for Tiles, **you can only use convex polygons**. If you need to make a concave polygon, use multiple tiles to achieve this.
 


### PR DESCRIPTION
Hello Jon and the Stencyl team. Its Donni11. I added to Troubleshooting, a note about keeping the tiles size the same for all tilesets and scenes 

Code:

 If they are not the same size, the tiles will be [invisible when testing or publishing the game](http://community.stencyl.com/index.php?issue=122.0).