### PR TITLE
Clarify attribute-types.md

### DIFF
--- a/chapter-2/attribute-types.md
+++ b/chapter-2/attribute-types.md
@@ -50,7 +50,7 @@ Text | ![stencyl-design-mode-text-type-attribute](http://static.stencyl.com/pedi
  
 ## Gotchas
 
-Something you might bump into fairly early on is this.
+Something you might bump into fairly early on is shown in the following image:
 
 ![Cannot configure](http://static.stencyl.com/pedia2/ch4/customize/image05.png)
 


### PR DESCRIPTION
From an internationalization point of view, the lack of clarity as to what "this" refers to is illogical and confusing. Furthermore, the sentence is not self-contained in its informational content, so "." should be replaced with ":" to indicate that one ought to read further to find closure.